### PR TITLE
[fix] swagger - 댓글 삭제 시 query 미 포함, jwt 중복 해결 (#73)

### DIFF
--- a/swagger/comment.swagger.yaml
+++ b/swagger/comment.swagger.yaml
@@ -179,7 +179,7 @@ paths:
     delete:
       tags:
         - Comment
-      summary: Delete comments for a post
+      summary: Delete comments (다중 삭제 기능 제공)
       parameters:
         - name: postId
           in: path
@@ -187,6 +187,14 @@ paths:
           schema:
             type: integer
             description: The ID of the post
+        - name: ids
+          in: query
+          required: false
+          schema:
+            type: string
+            description: 삭제할 댓글의 id값을 입력하세요.
+            example: "1,2,3"
+
       responses:
         200:
           description: Comments deleted successfully

--- a/swagger/likes.swagger.yaml
+++ b/swagger/likes.swagger.yaml
@@ -5,8 +5,6 @@ paths:
         - Like
       summary: Like a post
       description: Like a specific post by its ID.
-      security:
-        - bearerAuth: [ ]
       parameters:
         - name: postId
           in: path
@@ -61,8 +59,6 @@ paths:
         - Like
       summary: Like a comment
       description: Like a specific comment by its ID.
-      security:
-        - bearerAuth: [ ]
       parameters:
         - name: commentId
           in: path


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
#73 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
swagger  문서 작성 중 댓글 삭제 시 query 미 포함 수정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fb8aaab3-faf9-457e-b01e-147d019db476)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
